### PR TITLE
add `box-sizing: border-box` to remove unnecessary horizontal scroll

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -37,6 +37,10 @@
 }
 
 /* Base Styles */
+* {
+  box-sizing: border-box;
+}
+
 body {
     font-family: 'Montserrat', sans-serif;
     margin: 0;


### PR DESCRIPTION
In all the pages there is a horizontal scroll, with no content if you scroll it. The reason of this scroll appears to be the banner that says that the site is under development making an overflow and creating the scroll. The `box-sizing: border-box;` that i added solves this issue and removes the need to close the banner every single time.