### PR TITLE
Add hover color rule for download button

### DIFF
--- a/src/pages/video/VideoDetailPage.module.css
+++ b/src/pages/video/VideoDetailPage.module.css
@@ -93,6 +93,7 @@
 
 .downloadButton:hover {
   background-color: var(--color-accent-dark);
+  color: var(--color-white)
 }
 
 .donateButton {


### PR DESCRIPTION
This PR introduces a small UI improvement by adding a color rule to the hover state of the download button.

- Before: The button had no hover feedback.

- After: The button now changes color on hover, improving user experience and clarity of interaction.

Even though it’s a small change, I’d like to start contributing to this project and thought this could be a good first step.

### Before & After

| Before | After |
|--------|-------|
| <img width="601" alt="old" src="https://github.com/user-attachments/assets/2d4a3e13-8c68-4e15-8666-41f794841f78" /> | <img width="601" alt="new" src="https://github.com/user-attachments/assets/b00c6366-6ba5-4c5f-b98d-d518e2d4d15e" /> |

