### PR TITLE
Make tags clickable (for easier search)

### DIFF
--- a/components/app/video/VideoCard.tsx
+++ b/components/app/video/VideoCard.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import Image from "next/image";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 type VideoCardProps = {
   thumbnailUrl: string | null;
@@ -38,12 +39,23 @@ export function VideoCard({
   const isLarge = variant === "listLarge";
   const imgSrc = thumbnailUrl ?? undefined;
 
+  const router = useRouter();
+
   const cardWrapper = (children: React.ReactNode, classes: string) => {
     if (href) {
+      // use div with click handler instead of Link to avoid nested anchors
       return (
-        <Link href={href} className={classes}>
+        <div
+          className={classes}
+          role="link"
+          tabIndex={0}
+          onClick={() => router.push(href)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") router.push(href);
+          }}
+        >
           {children}
-        </Link>
+        </div>
       );
     }
 
@@ -109,12 +121,17 @@ export function VideoCard({
                   }}
                 >
                   {tags.map((tag) => (
-                    <span
+                    <Link
                       key={tag}
-                      className="text-xs px-2.5 py-1 rounded-full bg-white/10 text-(--gray-200) whitespace-nowrap"
+                      href={`/search?q=${encodeURIComponent(tag)}`}
+                      className="text-xs px-2.5 py-1 rounded-full bg-white/10 text-(--gray-200) whitespace-nowrap cursor-pointer hover:bg-white/20"
+                      onClick={(e) => {
+                        // prevent the card's onClick handler from firing when a tag is clicked
+                        e.stopPropagation();
+                      }}
                     >
                       {tag}
-                    </span>
+                    </Link>
                   ))}
                 </div>
               </div>

--- a/components/app/video/VideoDescription.tsx
+++ b/components/app/video/VideoDescription.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import Link from "next/link";
 import { VideoDetails } from "@/lib/video";
 
 interface VideoDescriptionProps {
@@ -29,12 +30,13 @@ export default function VideoDescription({ video }: VideoDescriptionProps) {
         {video.tags && video.tags.length > 0 && (
           <div className="flex flex-nowrap gap-2.5 overflow-hidden">
             {video.tags.map((tag) => (
-              <span
+              <Link
                 key={tag}
-                className="text-sm text-accent whitespace-nowrap shrink-0"
+                href={`/search?q=${encodeURIComponent(tag)}`}
+                className="text-sm text-accent whitespace-nowrap shrink-0 cursor-pointer hover:underline"
               >
                 #{tag}
-              </span>
+              </Link>
             ))}
           </div>
         )}


### PR DESCRIPTION
- I made video tags clickable so that it's easier to find similar videos
- Going forward, it would be good to make video tag (and maybe description) content included in search, too. Videos cannot be found by their tags rn.

**Changes:**
<img width="148" height="41" alt="image" src="https://github.com/user-attachments/assets/c5b26f75-0221-44ab-9baf-b46a85611b6b" />
<img width="140" height="177" alt="image" src="https://github.com/user-attachments/assets/7cb07ead-3a6a-44de-950a-3c3bc703ccc2" />
