### PR TITLE
fix(upload): chunks upload instead of multipart

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ docs/         Repository-level technical documentation
 - Sensitive areas are checked server-side against the backend session and reinforced client-side with sanitized callback URLs.
 - Protected routes distinguish between an expired session and a temporarily unavailable auth backend, redirecting the latter to a dedicated recovery screen instead of treating it as a logout.
 - Client-side auth hydration preserves a distinct "service unavailable" state so public surfaces do not misleadingly fall back to login prompts when the auth backend is down.
-- Uploads are sent as multipart form data to the backend.
+- Large video uploads automatically use the backend chunked-upload flow instead of a single monolithic request.
 
 For a more detailed technical walkthrough, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -1,6 +1,6 @@
 ﻿"use client";
 
-import { useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useForm } from "react-hook-form";
 import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -15,7 +15,15 @@ import ThumbnailDropzone from "./components/thumbnail-dropzone";
 import UploadProgress from "./components/upload-progress";
 import UploadDetailsFormFields from "./components/details-fields";
 import UploadStepScreen from "./components/upload-step";
-import { UPLOAD_STEPS, type UploadStep } from "./upload-constants";
+import {
+  DEFAULT_UPLOADING_LABEL,
+  MAX_THUMBNAIL_BYTES,
+  MAX_THUMBNAIL_MB,
+  MAX_VIDEO_UPLOAD_TOTAL_BYTES,
+  MAX_VIDEO_UPLOAD_TOTAL_MB,
+  UPLOAD_STEPS,
+  type UploadStep,
+} from "./upload-constants";
 import { uploadVideo } from "./upload-api";
 import {
   createIdleUploadRequestState,
@@ -50,6 +58,7 @@ export default function UploadPage() {
   const [thumbnailFile, setThumbnailFile] = useState<File | null>(null);
   const [thumbnailError, setThumbnailError] = useState<string | null>(null);
   const [currentStep, setCurrentStep] = useState<UploadStep>(1);
+  const uploadAbortControllerRef = useRef<AbortController | null>(null);
 
   const {
     register,
@@ -82,6 +91,13 @@ export default function UploadPage() {
     reset();
   };
 
+  useEffect(() => {
+    return () => {
+      uploadAbortControllerRef.current?.abort();
+      uploadAbortControllerRef.current = null;
+    };
+  }, []);
+
   const handleFileSelect = (nextFile: File | null) => {
     resetUploadSession();
     setCurrentStep(1);
@@ -95,6 +111,12 @@ export default function UploadPage() {
     if (!nextFile.type.startsWith("video/")) {
       setFile(null);
       setFileError("The selected file must be a video.");
+      return;
+    }
+
+    if (nextFile.size > MAX_VIDEO_UPLOAD_TOTAL_BYTES) {
+      setFile(null);
+      setFileError(`Videos are limited to ${MAX_VIDEO_UPLOAD_TOTAL_MB} MB.`);
       return;
     }
 
@@ -116,6 +138,12 @@ export default function UploadPage() {
       return;
     }
 
+    if (nextFile.size > MAX_THUMBNAIL_BYTES) {
+      setThumbnailFile(null);
+      setThumbnailError(`Thumbnails are limited to ${MAX_THUMBNAIL_MB} MB.`);
+      return;
+    }
+
     setThumbnailFile(nextFile);
     setThumbnailError(null);
   };
@@ -128,19 +156,37 @@ export default function UploadPage() {
     }
 
     setCurrentStep(4);
-    setVideoRequest({ state: "uploading", progress: 0, error: null });
+    setVideoRequest({
+      state: "uploading",
+      progress: 0,
+      error: null,
+      uploadingLabel: DEFAULT_UPLOADING_LABEL,
+    });
 
     try {
+      const controller = new AbortController();
+      uploadAbortControllerRef.current = controller;
+
       await uploadVideo({
         file,
         thumbnail: thumbnailFile,
         values: data,
-        onProgress: (progress) => {
-          setVideoRequest((prev) => ({ ...prev, progress }));
+        signal: controller.signal,
+        onProgress: ({ progress, label }) => {
+          setVideoRequest((prev) => ({
+            ...prev,
+            progress,
+            uploadingLabel: label,
+          }));
         },
       });
 
-      setVideoRequest({ state: "done", progress: 100, error: null });
+      setVideoRequest({
+        state: "done",
+        progress: 100,
+        error: null,
+        uploadingLabel: DEFAULT_UPLOADING_LABEL,
+      });
 
       toast.success(
         thumbnailFile
@@ -149,8 +195,15 @@ export default function UploadPage() {
       );
     } catch (error) {
       const message = resolveUploadErrorMessage(error);
-      setVideoRequest((prev) => ({ ...prev, state: "error", error: message }));
+      setVideoRequest((prev) => ({
+        ...prev,
+        state: "error",
+        error: message,
+        uploadingLabel: DEFAULT_UPLOADING_LABEL,
+      }));
       toast.error(message);
+    } finally {
+      uploadAbortControllerRef.current = null;
     }
   };
 
@@ -277,6 +330,16 @@ export default function UploadPage() {
       case 4:
         return (
           <>
+            {isUploading && (
+              <Button
+                type="button"
+                variant="ghost"
+                className={secondaryActionClassName}
+                onClick={() => uploadAbortControllerRef.current?.abort()}
+              >
+                Cancel upload
+              </Button>
+            )}
             {videoRequest.state === "error" && (
               <Button
                 type="button"

--- a/app/upload/upload-api.ts
+++ b/app/upload/upload-api.ts
@@ -12,12 +12,108 @@ type UploadVideoResponse = {
   };
 };
 
-type ProgressHandler = (progress: number) => void;
+type ChunkedUploadInitResponse = {
+  uploadId: string;
+  chunkSizeBytes: number;
+  chunkSizeMB: number;
+  totalChunks: number;
+  totalSize: number;
+};
 
-const toPercentage = (event: AxiosProgressEvent) => {
-  const progressValue = event.progress ?? (event.total ? event.loaded / event.total : 0);
+type UploadProgressSnapshot = {
+  progress: number;
+  label: string;
+};
 
-  return clampPercentage(Math.round(progressValue * 100));
+type ProgressHandler = (snapshot: UploadProgressSnapshot) => void;
+
+const INIT_UPLOAD_TIMEOUT_MS = 30 * 1000;
+const CHUNK_UPLOAD_TIMEOUT_MS = 15 * 60 * 1000;
+const COMPLETE_UPLOAD_TIMEOUT_MS = 20 * 60 * 1000;
+
+const PREPARING_PROGRESS = 2;
+const CHUNK_PROGRESS_START = 5;
+const CHUNK_PROGRESS_END = 95;
+const FINALIZING_PROGRESS = 98;
+
+const emitProgress = (
+  onProgress: ProgressHandler | undefined,
+  progress: number,
+  label: string,
+) => {
+  onProgress?.({
+    progress: clampPercentage(Math.round(progress)),
+    label,
+  });
+};
+
+const buildInitPayload = (file: File, values: UploadFormValues) => {
+  const payload: Record<string, string | number | boolean> = {
+    title: values.title.trim(),
+    allowComments: values.allowComments ?? true,
+    license: values.license ?? "all_rights_reserved",
+    totalSize: file.size,
+    originalName: file.name,
+  };
+
+  if (file.type) {
+    payload.mimeType = file.type;
+  }
+
+  if (values.description) {
+    const description = values.description.trim();
+    if (description.length > 0) {
+      payload.description = description;
+    }
+  }
+
+  if (values.tags) {
+    const normalizedTags = normalizeTags(values.tags).join(",");
+    if (normalizedTags.length > 0) {
+      payload.tags = normalizedTags;
+    }
+  }
+
+  return payload;
+};
+
+const getChunkUploadLabel = (chunkIndex: number, totalChunks: number) =>
+  totalChunks > 1 ? `Uploading chunk ${chunkIndex + 1} of ${totalChunks}` : "Uploading video";
+
+const mapChunkProgress = (uploadedBytes: number, totalBytes: number) => {
+  const safeTotalBytes = Math.max(totalBytes, 1);
+  const ratio = Math.max(0, Math.min(1, uploadedBytes / safeTotalBytes));
+  return CHUNK_PROGRESS_START + ratio * (CHUNK_PROGRESS_END - CHUNK_PROGRESS_START);
+};
+
+const createChunkFormData = (chunk: Blob, chunkIndex: number, fileName: string) => {
+  const formData = new FormData();
+  formData.append("chunkIndex", String(chunkIndex));
+  formData.append("chunk", chunk, `${fileName}.part-${chunkIndex}`);
+  return formData;
+};
+
+const createCompletionFormData = (thumbnail?: File | null) => {
+  const formData = new FormData();
+  if (thumbnail) {
+    formData.append("thumbnail", thumbnail);
+  }
+  return formData;
+};
+
+const abortChunkedUpload = async (uploadId: string) => {
+  try {
+    await api.delete(`/upload/video-chunks/${encodeURIComponent(uploadId)}`, {
+      timeout: INIT_UPLOAD_TIMEOUT_MS,
+    });
+  } catch {
+    // Best-effort cleanup only.
+  }
+};
+
+const toLoadedBytes = (event: AxiosProgressEvent, chunkSize: number) => {
+  const loadedBytes = event.loaded ?? 0;
+  return Math.max(0, Math.min(chunkSize, loadedBytes));
 };
 
 export const uploadVideo = async ({
@@ -25,44 +121,81 @@ export const uploadVideo = async ({
   thumbnail,
   values,
   onProgress,
+  signal,
 }: {
   file: File;
   thumbnail?: File | null;
   values: UploadFormValues;
   onProgress?: ProgressHandler;
+  signal?: AbortSignal;
 }) => {
-  const formData = new FormData();
+  let uploadId: string | null = null;
 
-  formData.append("title", values.title.trim());
-  formData.append("video", file);
-  formData.append("allowComments", String(values.allowComments ?? true));
-  formData.append("license", values.license ?? "all_rights_reserved");
-  if (thumbnail) {
-    formData.append("thumbnail", thumbnail);
-  }
+  try {
+    emitProgress(onProgress, PREPARING_PROGRESS, "Preparing upload");
 
-  if (values.description) {
-    const description = values.description.trim();
-    if (description.length > 0) {
-      formData.append("description", description);
+    const initResponse = await api.post<ChunkedUploadInitResponse>(
+      "/upload/video-chunks/init",
+      buildInitPayload(file, values),
+      {
+        signal,
+        timeout: INIT_UPLOAD_TIMEOUT_MS,
+      },
+    );
+
+    uploadId = initResponse.data.uploadId;
+    const { chunkSizeBytes, totalChunks } = initResponse.data;
+
+    let uploadedBytes = 0;
+
+    for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex += 1) {
+      const start = chunkIndex * chunkSizeBytes;
+      const end = Math.min(start + chunkSizeBytes, file.size);
+      const chunk = file.slice(start, end);
+      const label = getChunkUploadLabel(chunkIndex, totalChunks);
+
+      await api.post(
+        `/upload/video-chunks/${encodeURIComponent(uploadId)}/chunk`,
+        createChunkFormData(chunk, chunkIndex, file.name),
+        {
+          signal,
+          timeout: CHUNK_UPLOAD_TIMEOUT_MS,
+          onUploadProgress: (event) => {
+            const currentChunkBytes = toLoadedBytes(event, chunk.size);
+            emitProgress(
+              onProgress,
+              mapChunkProgress(uploadedBytes + currentChunkBytes, file.size),
+              label,
+            );
+          },
+        },
+      );
+
+      uploadedBytes += chunk.size;
+      emitProgress(onProgress, mapChunkProgress(uploadedBytes, file.size), label);
     }
-  }
 
-  if (values.tags) {
-    const normalizedTags = normalizeTags(values.tags).join(",");
-    if (normalizedTags.length > 0) {
-      formData.append("tags", normalizedTags);
+    emitProgress(
+      onProgress,
+      FINALIZING_PROGRESS,
+      thumbnail ? "Uploading thumbnail and finalizing" : "Finalizing upload",
+    );
+
+    const response = await api.post<UploadVideoResponse>(
+      `/upload/video-chunks/${encodeURIComponent(uploadId)}/complete`,
+      createCompletionFormData(thumbnail),
+      {
+        signal,
+        timeout: COMPLETE_UPLOAD_TIMEOUT_MS,
+      },
+    );
+
+    return response.data.video;
+  } catch (error) {
+    if (uploadId) {
+      await abortChunkedUpload(uploadId);
     }
+
+    throw error;
   }
-
-  const response = await api.post<UploadVideoResponse>("/upload/video-bundle", formData, {
-    headers: {
-      "Content-Type": "multipart/form-data",
-    },
-    onUploadProgress: (event) => {
-      onProgress?.(toPercentage(event));
-    },
-  });
-
-  return response.data.video;
 };

--- a/app/upload/upload-constants.ts
+++ b/app/upload/upload-constants.ts
@@ -1,6 +1,14 @@
 export type UploadState = "idle" | "uploading" | "done" | "error";
 export type UploadStep = 1 | 2 | 3 | 4;
 
+const MEBIBYTE = 1024 * 1024;
+
+export const MAX_VIDEO_UPLOAD_TOTAL_BYTES = 3040 * MEBIBYTE;
+export const MAX_VIDEO_UPLOAD_TOTAL_MB = Math.round(MAX_VIDEO_UPLOAD_TOTAL_BYTES / MEBIBYTE);
+export const MAX_THUMBNAIL_BYTES = 5 * MEBIBYTE;
+export const MAX_THUMBNAIL_MB = Math.round(MAX_THUMBNAIL_BYTES / MEBIBYTE);
+export const DEFAULT_UPLOADING_LABEL = "Uploading video";
+
 export const UPLOAD_STEPS = [
   { id: 1, title: "File" },
   { id: 2, title: "Details" },

--- a/app/upload/upload-helpers.ts
+++ b/app/upload/upload-helpers.ts
@@ -1,38 +1,34 @@
 import type { UploadState } from "./upload-constants";
+import { DEFAULT_UPLOADING_LABEL } from "./upload-constants";
+import { getApiErrorMessage } from "../../lib/api-error";
 
 export type UploadRequestState = {
   state: UploadState;
   progress: number;
   error: string | null;
+  uploadingLabel: string;
 };
 
 export const createIdleUploadRequestState = (): UploadRequestState => ({
   state: "idle",
   progress: 0,
   error: null,
+  uploadingLabel: DEFAULT_UPLOADING_LABEL,
 });
 
 export const resolveUploadErrorMessage = (error: unknown, fallback = "Something went wrong!") => {
   const responseData = (
     error as {
-      response?: { data?: { error?: string; message?: string } };
+      code?: string;
+      name?: string;
     }
-  )?.response?.data;
-  const message = responseData?.error ?? responseData?.message;
+  );
 
-  if (typeof message === "string" && message.trim().length > 0) {
-    return message;
+  if (responseData?.code === "ERR_CANCELED" || responseData?.name === "CanceledError") {
+    return "Upload canceled.";
   }
 
-  if (typeof error === "string" && error.trim().length > 0) {
-    return error;
-  }
-
-  if (error instanceof Error && error.message.trim().length > 0) {
-    return error.message;
-  }
-
-  return fallback;
+  return getApiErrorMessage(error, fallback);
 };
 
 export const getCombinedUploadState = ({ video }: { video: UploadRequestState }) => {
@@ -42,7 +38,7 @@ export const getCombinedUploadState = ({ video }: { video: UploadRequestState })
 
   const labels = {
     idle: "Ready to upload",
-    uploading: "Uploading video",
+    uploading: video.uploadingLabel || DEFAULT_UPLOADING_LABEL,
     done: "Upload complete",
     error: "Upload failed",
   };

--- a/components/marketing/sections/FeatureSection.tsx
+++ b/components/marketing/sections/FeatureSection.tsx
@@ -28,7 +28,7 @@ const features = [
     title: "Watch the way",
     titleAccent: "you want.",
     description:
-      "Toggle ambilight for an immersive glow, switch between light and dark mode, or dial in a custom accent colour. Your setup, saved automatically.",
+      "Toggle ambilight for an immersive glow, switch between light and dark mode, or enter theatre mode. Your setup, saved automatically.",
     screenshot: "/screenshots/feature-customization.png",
     alt: "Player customization panel with ambilight and theme options",
     imageLeft: false,
@@ -52,7 +52,7 @@ function FeatureRow({
     >
       <div className="w-full md:w-3/5">
         <div className="group">
-          <BrowserFrame url="lab.fairplay.video">
+          <BrowserFrame url="fairplay.video">
             <Image
               src={screenshot}
               alt={alt}

--- a/components/marketing/sections/HeroSection.tsx
+++ b/components/marketing/sections/HeroSection.tsx
@@ -105,11 +105,11 @@ function StatDisplay({ value, label }: StatItem) {
 export default function HeroSection({
   titleLine1 = "The video platform",
   titleLine2 = "that plays fair.",
-  description = "An open-source project for a healthier internet, built around transparency, fairness, and creators.",
+  description = "An open-source project for a healthier internet, built around transparency, fairness, and users.",
   primaryCTA = "Explore the app",
   primaryCTAHref = "/explore?popup",
   secondaryCTA = "Watch Intro",
-  secondaryCTAHref = "https://lab.fairplay.video/video/b79f9273-16de-434c-8f69-4fd9f1a2f959",
+  secondaryCTAHref = "https://fairplay.video/video/QGdnptWkwU",
   stats = DEFAULT_STATS,
 }: HeroProps) {
   const [animate, setAnimate] = useState(false);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -329,7 +329,13 @@ The upload flow is implemented as a client-side multi-step process:
 3. optionally add a thumbnail
 4. upload and monitor progress
 
-The actual upload request is sent as `multipart/form-data` to `/upload/video-bundle`.
+The upload client automatically switches to the chunked backend flow for video files:
+
+1. `POST /upload/video-chunks/init`
+2. `POST /upload/video-chunks/:uploadId/chunk`
+3. `POST /upload/video-chunks/:uploadId/complete`
+
+Large videos are therefore streamed in multiple requests instead of a single monolithic `video-bundle` request.
 
 ### Moderator and Admin
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -957,9 +957,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.12",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
-      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5442,14 +5442,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -7649,9 +7649,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -8247,9 +8247,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10837,10 +10837,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",


### PR DESCRIPTION
Refactored the frontend to use dedicated chunked upload endpoints instead of the old multipart approach for videos larger than 95Mb.

The previous multipart upload flow was incompatible with Cloudflare’s request size limits. This update switches to a chunked upload for videos >95Mb.